### PR TITLE
fixed type of note not showing when adding one

### DIFF
--- a/app/Life/Controllers/Admin/NoteController.php
+++ b/app/Life/Controllers/Admin/NoteController.php
@@ -50,6 +50,18 @@ class NoteController extends Controller
         if ($req_validation->failed()) {
             return $response->withJson(["error" => "Message Cant Be Blank!"], 400);
         }
+        
+        switch ($note->type) {
+            case 0:
+                $name = "Information";
+                break;
+            case 1:
+                $name = "Warning";
+                break;
+            case 2:
+                $name = "Other";
+                break;
+        }
 
         $type = $request->getParam('type');
         if ($type > 2) $type = 2;


### PR DESCRIPTION
the type of note that was added would not be displayed in the log, this change fixed it.

(removing notes did show the type btw)