### PR TITLE
Fixed typo in compensate button

### DIFF
--- a/resources/lang/en/life.php
+++ b/resources/lang/en/life.php
@@ -70,7 +70,7 @@ return array (
             'id' => 'SteamID',
         ),
         'buttons' => array (
-            'compensate' => 'Compenstae',
+            'compensate' => 'Compensate',
             'addNote' => 'Add Note',
         ),
         'tabs' => array (


### PR DESCRIPTION
Compensate is spelt wrong